### PR TITLE
The behavior of notificationReceived on Android is the same as iOS.

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.6.0
+version: 1.6.1
 apiversion: 3
 architectures: armeabi-v7a x86
 description: com.williamrijksen.onesignal

--- a/android/src/com/williamrijksen/onesignal/ComWilliamrijksenOnesignalModule.java
+++ b/android/src/com/williamrijksen/onesignal/ComWilliamrijksenOnesignalModule.java
@@ -168,15 +168,25 @@ public class ComWilliamrijksenOnesignalModule extends KrollModule
 	private class NotificationReceivedHandler implements OneSignal.NotificationReceivedHandler {
 		@Override
 		public void notificationReceived(OSNotification notification) {
+			HashMap<String, Object> kd = new HashMap<String, Object>();
+
+			String title = notification.payload.title;
+			if (title != null) {
+				kd.put("title", title);
+			}
+
+			String body = notification.payload.body;
+			if (body != null) {
+				kd.put("body", body);
+			}
+
 			JSONObject additionalData = notification.payload.additionalData;
 			if(additionalData != null){
-				String payload = additionalData.toString();
-				HashMap<String, Object> kd = new HashMap<String, Object>();
-				kd.put("additionalData", payload);
-				fireEvent("notificationReceived", kd);
-			}else{
-				Log.d(LCAT, "No additionalData on notification payload =/");
+				String additional = additionalData.toString();
+				kd.put("additionalData", additional);
 			}
+
+			fireEvent("notificationReceived", kd);
 		}
 	}
 }


### PR DESCRIPTION
On Android, additionalData must be present for notificationReceived event to occur.

Even if there is only Title and Body, it is need to fire event.

The iOS version in your module is working like that.

Because, I'm make to the behavior of notificationReceived on Android is the same as iOS.

I confirmed that I built it and it works, but your policy did not seem to upload the module zip file, so I omitted it.

Thank you!
