### PR TITLE
Changes for when app can not receive the notificationOpened event for…

### DIFF
--- a/android/src/com/williamrijksen/onesignal/ComWilliamrijksenOnesignalModule.java
+++ b/android/src/com/williamrijksen/onesignal/ComWilliamrijksenOnesignalModule.java
@@ -150,8 +150,13 @@ public class ComWilliamrijksenOnesignalModule extends KrollModule
 				try {
 					OSNotificationPayload payload = result.notification.payload;
 
-					if (getModuleInstance().hasListeners("notificationOpened") && payload != null) {
-						getModuleInstance().fireEvent("notificationOpened", payload.toJSONObject());
+					if (payload != null) {
+						if (getModuleInstance().hasListeners("notificationOpened")) {
+							getModuleInstance().fireEvent("notificationOpened", payload.toJSONObject());
+						} else {
+							// save the notification for later processing
+							openNotification = result;
+						}
 					}
 				} catch (Throwable t) {
 					Log.d(LCAT, "com.williamrijksen.onesignal OSNotificationOpenResult could not be converted to JSON");

--- a/android/src/com/williamrijksen/onesignal/ComWilliamrijksenOnesignalModule.java
+++ b/android/src/com/williamrijksen/onesignal/ComWilliamrijksenOnesignalModule.java
@@ -146,7 +146,7 @@ public class ComWilliamrijksenOnesignalModule extends KrollModule
 		public void notificationOpened(OSNotificationOpenResult result)
 		{
 			Log.d(LCAT, "com.williamrijksen.onesignal Notification opened handler");
-			if (getModuleInstance() != null) {
+			if (TiApplication.getAppCurrentActivity() != null && getModuleInstance() != null) {
 				try {
 					OSNotificationPayload payload = result.notification.payload;
 
@@ -174,7 +174,7 @@ public class ComWilliamrijksenOnesignalModule extends KrollModule
 		public void notificationReceived(OSNotification notification)
 		{
 			Log.d(LCAT, "com.williamrijksen.onesignal Notification received handler");
-			if (getModuleInstance() != null) {
+			if (TiApplication.getAppCurrentActivity() != null && getModuleInstance() != null) {
 				try {
 					OSNotificationPayload payload = notification.payload;
 


### PR DESCRIPTION
I am very grateful that this module has been continuously updated.

This PR has little changes.

Changes for when the app can not receive the notificationOpened event for android.
(When the app is suspended or not yet have a notificationOpened event handler.)

Currently version 1.7.1, if the app is suspended after being launched, the app can't to receive events for notificationOpened.

Thank you.