### PR TITLE
Do not auto trigger the location permission request

### DIFF
--- a/ios/Classes/ComWilliamrijksenOnesignalModule.m
+++ b/ios/Classes/ComWilliamrijksenOnesignalModule.m
@@ -64,11 +64,13 @@ NSString * const NotificationOpened = @"notificationOpened";
     };
 
     NSString *OneSignalAppID = [[TiApp tiAppProperties] objectForKey:@"OneSignal_AppID"];
+    [OneSignal setLocationShared:NO];
     [OneSignal initWithLaunchOptions:launchOptions
                                appId:OneSignalAppID
           handleNotificationReceived:notificationReceivedBlock
             handleNotificationAction:notificationOpenedBlock
                             settings:onesignalInitSettings];
+    [OneSignal setLocationShared:YES];
 
     return YES;
 }


### PR DESCRIPTION
When using the OneSignal library, the current situation also automatically asks for location permissions. This should be done by the one implementing this functionality to have full control over the way permissions are required.